### PR TITLE
chore: release v1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.0.13](https://github.com/pacman82/odbcsv/compare/v1.0.12...v1.0.13) - 2025-02-17
+
+### Other
+
+- Update to odbc-api 11
+- *(deps)* bump tempfile from 3.16.0 to 3.17.0
+- *(deps)* bump clap from 4.5.28 to 4.5.29
+- *(deps)* bump clap from 4.5.27 to 4.5.28
+- *(deps)* bump tempfile from 3.15.0 to 3.16.0
+- *(deps)* bump log from 0.4.22 to 0.4.25
+- *(deps)* bump clap from 4.5.26 to 4.5.27
+- *(deps)* bump clap from 4.5.24 to 4.5.26
+- *(deps)* bump clap from 4.5.23 to 4.5.24
+- *(deps)* bump odbc-api from 10.1.0 to 10.1.1
+- *(deps)* bump tempfile from 3.14.0 to 3.15.0
+- Remove superfluos workaround for arm macs
+- *(deps)* bump anyhow from 1.0.94 to 1.0.95
+- *(deps)* bump clap from 4.5.22 to 4.5.23
+- *(deps)* bump anyhow from 1.0.93 to 1.0.94
+- *(deps)* bump clap from 4.5.21 to 4.5.22
+- *(deps)* bump odbc-api from 9.0.0 to 10.0.0
+
 ## [1.0.12](https://github.com/pacman82/odbcsv/compare/v1.0.11...v1.0.12) - 2024-11-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbcsv"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbcsv"
-version = "1.0.12"
+version = "1.0.13"
 authors = ["Markus Klein"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `odbcsv`: 1.0.12 -> 1.0.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.13](https://github.com/pacman82/odbcsv/compare/v1.0.12...v1.0.13) - 2025-02-17

### Other

- Update to odbc-api 11
- *(deps)* bump tempfile from 3.16.0 to 3.17.0
- *(deps)* bump clap from 4.5.28 to 4.5.29
- *(deps)* bump clap from 4.5.27 to 4.5.28
- *(deps)* bump tempfile from 3.15.0 to 3.16.0
- *(deps)* bump log from 0.4.22 to 0.4.25
- *(deps)* bump clap from 4.5.26 to 4.5.27
- *(deps)* bump clap from 4.5.24 to 4.5.26
- *(deps)* bump clap from 4.5.23 to 4.5.24
- *(deps)* bump odbc-api from 10.1.0 to 10.1.1
- *(deps)* bump tempfile from 3.14.0 to 3.15.0
- Remove superfluos workaround for arm macs
- *(deps)* bump anyhow from 1.0.94 to 1.0.95
- *(deps)* bump clap from 4.5.22 to 4.5.23
- *(deps)* bump anyhow from 1.0.93 to 1.0.94
- *(deps)* bump clap from 4.5.21 to 4.5.22
- *(deps)* bump odbc-api from 9.0.0 to 10.0.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).