### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.1.2](https://github.com/pacman82/odbcsv/compare/v1.1.1...v1.1.2) - 2026-03-31
+
+### Other
+
+- Remove dev image from docker-compose.yml
+- Update to odbc-api 24
+- *(deps)* bump odbc-api from 22.0.0 to 23.0.1
+- *(deps)* bump odbc-api from 21.1.0 to 22.0.0
+- *(deps)* bump odbc-api from 21.0.0 to 21.1.0
+- *(deps)* bump clap from 4.5.60 to 4.6.0
+- *(deps)* bump assert_cmd from 2.1.2 to 2.2.0
+- *(deps)* bump tempfile from 3.26.0 to 3.27.0
+- *(deps)* bump odbc-api from 20.2.0 to 21.0.0
+- *(deps)* bump odbc-api from 20.1.3 to 20.2.0
+- *(deps)* bump tempfile from 3.25.0 to 3.26.0
+- *(deps)* bump anyhow from 1.0.101 to 1.0.102
+- *(deps)* bump clap from 4.5.59 to 4.5.60
+- *(deps)* bump odbc-api from 20.1.2 to 20.1.3
+- *(deps)* bump clap from 4.5.58 to 4.5.59
+- *(deps)* bump odbc-api from 20.1.1 to 20.1.2
+- *(deps)* bump clap from 4.5.57 to 4.5.58
+- *(deps)* bump tempfile from 3.24.0 to 3.25.0
+- *(deps)* bump anyhow from 1.0.100 to 1.0.101
+- *(deps)* bump clap from 4.5.56 to 4.5.57
+- *(deps)* bump clap from 4.5.55 to 4.5.56
+- *(deps)* bump clap from 4.5.54 to 4.5.55
+- *(deps)* bump odbc-api from 20.1.0 to 20.1.1
+- *(deps)* bump assert_cmd from 2.1.1 to 2.1.2
+
 ## [1.1.1](https://github.com/pacman82/odbcsv/compare/v1.1.0...v1.1.1) - 2026-01-05
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.2](https://github.com/pacman82/odbcsv/compare/v1.1.1...v1.1.2) - 2026-01-05
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated dependencies
+
 ## [1.1.1](https://github.com/pacman82/odbcsv/compare/v1.1.0...v1.1.1) - 2026-01-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ checksum = "245cb4fe8236df4fd352ba96075d754233c6509d654d9f1c1482158b7d6c083d"
 
 [[package]]
 name = "odbcsv"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbcsv"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Markus Klein"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `odbcsv`: 1.1.1 -> 1.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/pacman82/odbcsv/compare/v1.1.0...v1.1.1) - 2026-01-05

### Other

- replace cargo_bin! with cargo_bin_cmd!
- Use cargo_bin! macro instead of deprecated function
- *(deps)* bump log from 0.4.28 to 0.4.29
- *(deps)* bump odbc-api from 20.0.0 to 20.1.0
- *(deps)* bump odbc-api from 19.1.0 to 20.0.0
- *(deps)* bump actions/checkout from 5 to 6
- *(deps)* bump clap from 4.5.52 to 4.5.53
- *(deps)* bump clap from 4.5.51 to 4.5.52
- *(deps)* bump clap from 4.5.50 to 4.5.51
- *(deps)* bump assert_cmd from 2.1.0 to 2.1.1
- *(deps)* bump assert_cmd from 2.0.17 to 2.1.0
- *(deps)* bump clap from 4.5.49 to 4.5.50
- *(deps)* bump csv from 1.3.1 to 1.4.0
- *(deps)* bump clap from 4.5.48 to 4.5.49
- *(deps)* bump odbc-api from 19.0.2 to 19.1.0
- *(deps)* bump odbc-api from 19.0.1 to 19.0.2
- *(deps)* bump tempfile from 3.22.0 to 3.23.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).